### PR TITLE
'moon_phases' key commented out in Norwegian language file

### DIFF
--- a/lang/no.conf
+++ b/lang/no.conf
@@ -7,7 +7,8 @@
 [Almanac]
 
     # The labels to be used for the phases of the moon:
-    moon_phases = Nymåne, Voksende sigd, Første kvarter, Voksende måne, Fullmåne, Avtakende måne, Siste kvarter, Avtakende sigd
+    # (commented out because already included in the skin's language file)
+    #moon_phases = Nymåne, Voksende sigd, Første kvarter, Voksende måne, Fullmåne, Avtakende måne, Siste kvarter, Avtakende sigd
 
     # Phases of the inner planets:
     mercury_phases = Ny, Voksende sigd, Første kvarter, Voksende, Full, Avtakende, Siste kvarter, Avtakende sigd


### PR DESCRIPTION
Commenting out 'moon_phases' key was not done in the Norwegian language file