### PR TITLE
Corrected translation of "Distance"

### DIFF
--- a/lang/no.conf
+++ b/lang/no.conf
@@ -58,7 +58,7 @@
 
     [[Astronomical]]
 
-        Distance = Avstand # fra et himmellegeme
+        Distance = Avstand
         Magnitude = Magnitude
         First point of Aries = Værens punkt
         Apparent size = Tilsynelatende størrelse


### PR DESCRIPTION
I checked your example https://github.com/roe-dl/weewx-skymap-almanac/tree/master/examples/Seasons, and I the translation of "Distance" became wrong. I removed the "# fra et himmellegeme"-part from the translation. It was meant to be a comment.